### PR TITLE
add support for sorucehut

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -55,6 +55,15 @@ let
             );
         shortRev = builtins.substring 0 7 info.rev;
       }
+    else if info.type == "sourcehut" then
+      { inherit (info) rev narHash lastModified;
+        outPath =
+          fetchTarball
+            ({ url = "https://${info.host or "git.sr.ht"}/${info.owner}/${info.repo}/archive/${info.rev}.tar.gz"; }
+             // (if info ? narHash then { sha256 = info.narHash; } else {})
+            );
+        shortRev = builtins.substring 0 7 info.rev;
+      }
     else
       # FIXME: add Mercurial, tarball inputs.
       throw "flake input has unsupported input type '${info.type}'";


### PR DESCRIPTION
Mostly based on gitlab fetcher
Tarball link template from [nix source code](https://github.com/NiOS/nix/blob/d3e2394e9106416e57cd0da10facd8db00e622e6/src/libfetchers/github.cc#L445)

Note: i did test this only with offical sourcehut instance in [sourcehut:~p00f/clangd_extensions.nvim](https://git.sr.ht/~p00f/clangd_extensions.nvim) on [MyConfig (nixos, home manger, etc)](https://github.com/Alper-Celik/MyConfig) at [here](https://github.com/Alper-Celik/MyConfig/blob/45de860b0d96ac915c7ef094c4212467ec88ef47/flake.nix#L63) and [here](https://github.com/Alper-Celik/MyConfig/blob/45de860b0d96ac915c7ef094c4212467ec88ef47/Configs/Neovim/flake.nix#L47)